### PR TITLE
Fixes #5: new line separators regex

### DIFF
--- a/single-filez
+++ b/single-filez
@@ -37,7 +37,7 @@ async function run(options) {
 		options.url = fileUrl(options.url);
 	}
 	if (options.urlsFile) {
-		urls = fs.readFileSync(options.urlsFile).toString().split("\n");
+		urls = fs.readFileSync(options.urlsFile).toString().split(/\r?\n/);
 	} else {
 		urls = [options.url];
 	}
@@ -60,7 +60,7 @@ async function run(options) {
 
 function parseCookies(textValue) {
 	const httpOnlyRegExp = /^#HttpOnly_(.*)/;
-	return textValue.split(/\r\n|\n/)
+	return textValue.split(/\r?\n/)
 		.filter(line => line.trim() && (!/^#/.test(line) || httpOnlyRegExp.test(line)))
 		.map(line => {
 			const httpOnly = httpOnlyRegExp.test(line);


### PR DESCRIPTION
I don't know yesterday it wasn't working, I tested it out, today it's working fine on links list file :/ to be safe side, I'm raising PR to use `/\r?\n/` instead of using just `\n` in splitting lines for input file.